### PR TITLE
Fix zero arity function calls

### DIFF
--- a/lib/ecto_factory.ex
+++ b/lib/ecto_factory.ex
@@ -58,8 +58,8 @@ defmodule EctoFactory do
 
   """
   def insert(factory_name, attrs \\[]) do
-    unless repo, do: raise(EctoFactory.MissingRepo)
-    build(factory_name, attrs) |> repo.insert!()
+    unless repo(), do: raise(EctoFactory.MissingRepo)
+    build(factory_name, attrs) |> repo().insert!()
   end
 
   defp build_attrs(factory_name, attributes) do
@@ -74,7 +74,7 @@ defmodule EctoFactory do
   end
 
   defp factory(factory_name) do
-    case factories[factory_name] do
+    case factories()[factory_name] do
       nil               -> raise(EctoFactory.MissingFactory, factory_name)
       {model, defaults} -> {model, defaults}
       {model}           -> {model, []}

--- a/mix.exs
+++ b/mix.exs
@@ -10,9 +10,9 @@ defmodule EctoFactory.Mixfile do
       start_permanent: Mix.env == :prod,
       name: "EctoFactory",
       source_url: "https://github.com/mrmicahcooper/ecto_factory",
-      package: package,
-      description: description,
-      deps: deps,
+      package: package(),
+      description: description(),
+      deps: deps(),
       docs: [
         logo: "./logos/ectofactory_logo.png",
         extras: [


### PR DESCRIPTION
With the recent merge of https://github.com/elixir-lang/elixir/issues/3268 I was getting warnings such as:

```
warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
```

This fixes those ambiguous function calls. 