### PR TITLE
Allow elixir versions 1.10 and 1.11

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule EctoFactory.Mixfile do
     [
       app: :ecto_factory,
       version: "0.1.2",
-      elixir: "~> 1.9.1",
+      elixir: ">= 1.9.1",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       name: "EctoFactory",

--- a/test/ecto_factory_test.exs
+++ b/test/ecto_factory_test.exs
@@ -1,7 +1,7 @@
 defmodule EctoFactoryTest do
   use ExUnit.Case, async: true
 
-  Code.load_file("test/support/user.ex")
+  Code.require_file("test/support/user.ex")
 
   test "missing factory" do
     error_message = """


### PR DESCRIPTION
Added support for newer elixir versions.

I replaced a deprecated function. Tests all pass on Elixir versions 1.9, 1.10, and 1.11.