### PR TITLE
Custom ecto types support

### DIFF
--- a/lib/ecto_factory.ex
+++ b/lib/ecto_factory.ex
@@ -111,7 +111,7 @@ defmodule EctoFactory do
   #
   # Ecto Types must identify themselves with a type() function
   # https://hexdocs.pm/ecto/Ecto.Type.html
-  def gen(ecto_type_module) when is_atom(ecto_type_module), do: gen(ecto_type_module.type)
+  def gen(ecto_type_module) when is_atom(ecto_type_module), do: gen(ecto_type_module.type())
 
   # fallback to nil - this should probably raise
   def gen(_), do: nil
@@ -141,7 +141,7 @@ defmodule EctoFactory do
     {schema, attrs}
   end
 
-  defp gen_attribute({key, value}) when is_atom(value) and value not in [true, false], do: {key, gen(value)}
+  defp gen_attribute({key, value}) when is_atom(value) and value not in [true, false, nil], do: {key, gen(value)}
   defp gen_attribute({key, {_, _} = value}), do: {key, gen(value)}
   defp gen_attribute(key_value), do: key_value
 

--- a/lib/ecto_factory.ex
+++ b/lib/ecto_factory.ex
@@ -102,6 +102,17 @@ defmodule EctoFactory do
   # Special generators for helpful things
   def gen(:email), do: "#{gen(:string)}@#{gen(:string)}.#{gen(:string)}"
 
+  # Module names are atoms
+  # When the schema passes in a module, ask it for it's Ecto type
+  #
+  # schema "users" do
+  #   field(:balance, EctoURI)
+  # end
+  #
+  # Ecto Types must identify themselves with a type() function
+  # https://hexdocs.pm/ecto/Ecto.Type.html
+  def gen(ecto_type_module) when is_atom(ecto_type_module), do: gen(ecto_type_module.type)
+
   # fallback to nil - this should probably raise
   def gen(_), do: nil
 

--- a/test/ecto_factory_test.exs
+++ b/test/ecto_factory_test.exs
@@ -1,6 +1,7 @@
 defmodule EctoFactoryTest do
   use ExUnit.Case, async: true
 
+  Code.require_file("test/support/ecto_uri.ex")
   Code.require_file("test/support/user.ex")
 
   test "missing factory" do
@@ -22,6 +23,7 @@ defmodule EctoFactoryTest do
     user = EctoFactory.schema(User)
     assert user
     assert Enum.member?([true, false], user.admin)
+    assert is_map(user.avatar_url)
   end
 
   test "build with attributes" do

--- a/test/support/blog_post.ex
+++ b/test/support/blog_post.ex
@@ -1,0 +1,6 @@
+defmodule BlogPost do
+  use Ecto.Schema
+
+  schema "blog_posts" do
+  end
+end

--- a/test/support/ecto_uri.ex
+++ b/test/support/ecto_uri.ex
@@ -1,0 +1,33 @@
+defmodule EctoURI do
+  use Ecto.Type
+  def type, do: :map
+
+  # Provide custom casting rules.
+  # Cast strings into the URI struct to be used at runtime
+  def cast(uri) when is_binary(uri) do
+    {:ok, URI.parse(uri)}
+  end
+
+  # Accept casting of URI structs as well
+  def cast(%URI{} = uri), do: {:ok, uri}
+
+  # Everything else is a failure though
+  def cast(_), do: :error
+
+  # When loading data from the database, as long as it's a map,
+  # we just put the data back into an URI struct to be stored in
+  # the loaded schema struct.
+  def load(data) when is_map(data) do
+    data =
+      for {key, val} <- data do
+        {String.to_existing_atom(key), val}
+      end
+    {:ok, struct!(URI, data)}
+  end
+
+  # When dumping data to the database, we *expect* an URI struct
+  # but any value could be inserted into the schema struct at runtime,
+  # so we need to guard against them.
+  def dump(%URI{} = uri), do: {:ok, Map.from_struct(uri)}
+  def dump(_), do: :error
+end

--- a/test/support/role.ex
+++ b/test/support/role.ex
@@ -1,0 +1,6 @@
+defmodule Role do
+  use Ecto.Schema
+
+  schema "roles" do
+  end
+end

--- a/test/support/user.ex
+++ b/test/support/user.ex
@@ -1,5 +1,6 @@
 defmodule User do
   use Ecto.Schema
+  alias EctoURI
 
   schema "users" do
     field(:username)
@@ -8,5 +9,6 @@ defmodule User do
     field(:addresses, {:array, :string})
     field(:profile, :map)
     field(:admin, :boolean)
+    field(:avatar_url, EctoURI)
   end
 end

--- a/test/support/user.ex
+++ b/test/support/user.ex
@@ -10,5 +10,7 @@ defmodule User do
     field(:profile, :map)
     field(:admin, :boolean)
     field(:avatar_url, EctoURI)
+    has_many(:blog_posts, BlogPost)
+    belongs_to(:role, Role)
   end
 end


### PR DESCRIPTION
Add support for custom Ecto Types

`Ecto.Type`s must identify themselves by always implementing a `type()` function that corresponds to a native data type.
This is documented here: https://hexdocs.pm/ecto/Ecto.Type.html

My initial pull request broke relationship functionality.

This P/R adds support for custom Ecto types, while retaining relationships.